### PR TITLE
[#26] 방 설정 변경 partial api 추가

### DIFF
--- a/src/main/java/com/nexters/duckji/api/RoomController.java
+++ b/src/main/java/com/nexters/duckji/api/RoomController.java
@@ -3,6 +3,7 @@ package com.nexters.duckji.api;
 import javax.validation.Valid;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.nexters.duckji.domain.Room;
 import com.nexters.duckji.dto.ApiResponse;
 import com.nexters.duckji.dto.RoomRegisterRequest;
+import com.nexters.duckji.dto.update.RoomConfigUpdateRequest;
 import com.nexters.duckji.service.RoomService;
 
 import io.swagger.annotations.Api;
@@ -40,6 +42,14 @@ public class RoomController {
 	@GetMapping("/{roomId}")
 	public Mono<ApiResponse<Room>> getById(@PathVariable String roomId) {
 		return roomService.findById(roomId)
+				.map(ApiResponse::create)
+				.switchIfEmpty(Mono.just(ApiResponse.empty()));
+	}
+
+	@ApiOperation(value = "방 설정 변경", notes = "필드가 없는 경우 제거한다.")
+	@PatchMapping("/{roomId}")
+	public Mono<ApiResponse<Room>> getById(@RequestBody RoomConfigUpdateRequest request, @PathVariable String roomId) {
+		return roomService.patchConfigById(request, roomId)
 				.map(ApiResponse::create)
 				.switchIfEmpty(Mono.just(ApiResponse.empty()));
 	}

--- a/src/main/java/com/nexters/duckji/dto/update/RoomConfigUpdateRequest.java
+++ b/src/main/java/com/nexters/duckji/dto/update/RoomConfigUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.nexters.duckji.dto.update;
+
+import javax.validation.constraints.NotNull;
+
+import com.nexters.duckji.domain.RoomBackground;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RoomConfigUpdateRequest {
+	@NotNull
+	private String title;
+	private RoomBackground background;
+}

--- a/src/main/java/com/nexters/duckji/service/RoomService.java
+++ b/src/main/java/com/nexters/duckji/service/RoomService.java
@@ -3,14 +3,23 @@ package com.nexters.duckji.service;
 import static org.springframework.data.mongodb.core.query.Criteria.*;
 import static org.springframework.data.mongodb.core.query.Query.*;
 
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.mongodb.client.result.DeleteResult;
 import com.nexters.duckji.domain.Room;
 import com.nexters.duckji.dto.RoomRegisterRequest;
+import com.nexters.duckji.dto.update.RoomConfigUpdateRequest;
 import com.nexters.duckji.mapstruct.RoomMapper;
 import com.nexters.duckji.repository.RoomRepository;
+import com.nexters.duckji.util.JsonUtils;
+import com.nexters.duckji.util.MongoUtils;
 
 import reactor.core.publisher.Mono;
 
@@ -33,6 +42,21 @@ public class RoomService {
 
 	public Mono<Room> findById(String roomId) {
 		return roomRepository.findById(roomId);
+	}
+
+	public Mono<Room> patchConfigById(RoomConfigUpdateRequest updateRequest, String roomId) {
+		Criteria criteria = where("_id").is(roomId);
+		FindAndModifyOptions options = FindAndModifyOptions.options().returnNew(true);
+		Map<String, Object> partial = JsonUtils.convert(updateRequest, new TypeReference<>(){});
+
+		return Mono.just(MongoUtils.toUpdate(partial))
+				.map(update -> update.set("edtAt", LocalDateTime.now()))
+				.flatMap(update -> template.update(Room.class)
+						.matching(query(criteria))
+						.apply(update)
+						.withOptions(options)
+						.findAndModify()
+				);
 	}
 
 	public Mono<DeleteResult> deleteById(String roomId) {


### PR DESCRIPTION
방 설정이 추후 화면으로 나올수도 있을 것 같아서, 확장해서 제공합니다. 

- **PATCH /rooms/{roomId}**

```json
{
  "background": {
    "image": "http://~",
  },
  "title": "test"
}
```

### 필수 값 
- title

title을 지우려면 empty string으로 보내주세요 

<br>

### 이미지 삭제 예시

**1. image null 처리** 
- config 값들이 더 들어갈 수 있으니 이게 젤 무난할 것 같네요 

```json
{
  "background": {
    "image": null,
  },
  "title": "test"
}
```


**2. 필드 null 처리 혹은 제거** 

```json
{
  "title": "test"
}
```

```json
{
  "background": null
  "title": "test"
}
```

스웨거에 올려놨으니 테스트는 거기서 해주시면 됩니다용 